### PR TITLE
Centralise ratings to align with headings

### DIFF
--- a/src/components/ui/star-rating.tsx
+++ b/src/components/ui/star-rating.tsx
@@ -9,7 +9,7 @@ export function StarRating({ rating }: StarRatingProps) {
 	const MAX_STARS = 5;
 
 	return (
-		<div className="flex items-center">
+		<div className="flex items-center justify-center">
 			<div className="flex">
 				{[...Array(MAX_STARS)].map((_, index) => {
 					const fillPercentage = Math.max(


### PR DESCRIPTION
The star ratings aren't centralised, while their headings are, making them unaligned. This PR fixes that.

Desktop:
![Centralise ratings fix (desktop)](https://github.com/user-attachments/assets/37d8f3de-f115-49e2-9498-0286ef33acae)

Mobile:
![Centralise ratings fix (mobile)](https://github.com/user-attachments/assets/1303f6af-a9ea-491b-9181-4fbe831eda3d)