### PR TITLE
Preserve spacing and newlines, & break/wrap long words, in reviews

### DIFF
--- a/src/app/bakery/[id]/page.tsx
+++ b/src/app/bakery/[id]/page.tsx
@@ -75,7 +75,7 @@ export default async function BakeryPage({ params }: BakeryPageProps) {
 					<div className="prose prose-blue max-w-none">
 						<h2 className="text-2xl font-bold mb-4">Our Review</h2>
 						<div className="bg-gray-50 p-6 rounded-lg">
-							<blockquote className="text-lg text-gray-700 italic">
+							<blockquote className="text-lg text-gray-700 italic whitespace-pre-wrap break-words">
 								{bakery.review}
 							</blockquote>
 							<div className="mt-4 flex items-center justify-end gap-4">

--- a/src/components/home/recent-bakery.tsx
+++ b/src/components/home/recent-bakery.tsx
@@ -29,7 +29,7 @@ export async function RecentBakery() {
 					<div className="flex flex-col justify-center">
 						<div className="relative">
 							<Quote className="absolute -left-4 -top-4 h-8 w-8 text-blue-200" />
-							<blockquote className="pl-8 pr-4">
+							<blockquote className="pl-8 pr-4 whitespace-pre-wrap break-words">
 								<p className="text-lg text-gray-700 italic leading-relaxed">
 									{truncatedReview}
 								</p>


### PR DESCRIPTION
Currently, the reviews do not preserve the spacing and newlines present in them (#2), leading to reviews without paragraph breaks, with broken manual text alignment, and URLs or long words overflowing. While a better solution would be to overhaul the review editor & viewer, this PR gives a temporary fix so that at least the spacing and newlines can be shown, and long words wrapped.

Before & After:
![Respecting Newlines and breaking long words in reviews](https://github.com/user-attachments/assets/09036ef9-2d38-40f2-aabc-fde5747fd643)
(the screenshot above is from a bakery's page, but the featured bakery's section on the home page has also been taken care of)